### PR TITLE
Params struct refactor

### DIFF
--- a/packages/camera/CMakeLists.txt
+++ b/packages/camera/CMakeLists.txt
@@ -69,4 +69,8 @@ endif()
 
 install(DIRECTORY launch params DESTINATION share/${PROJECT_NAME})
 
+if(BUILD_TESTING)
+    add_subdirectory("test")
+endif()
+
 ament_package()

--- a/packages/camera/CMakeLists.txt
+++ b/packages/camera/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 install(DIRECTORY launch params DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
-    add_subdirectory("test")
+  add_subdirectory("test")
 endif()
 
 ament_package()

--- a/packages/camera/include/camera.h
+++ b/packages/camera/include/camera.h
@@ -55,6 +55,7 @@ class CameraNode : public rclcpp::Node {
   private:
     void applyParamsToCamera(int handle);
     int getCameraId(int camera_handle);
+    void initCalibParams(int camera_handle);
 
     void triggerOnTimer();
     void handleFrame(CameraHandle handle, BYTE* raw_buffer, tSdkFrameHead* frame_info);

--- a/packages/camera/include/params.h
+++ b/packages/camera/include/params.h
@@ -16,9 +16,6 @@ struct CameraIntrinsicParameters {
 
     void storeYaml(const std::string& yaml_path) const;
     static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path, int camera_id = 0);
-    static CameraIntrinsicParameters loadFromParams(
-        cv::Size param_image_size, const std::vector<double>& param_camera_matrix,
-        const std::vector<double>& param_dist_coefs);
     static bool saveStereoCalibration(
         const std::string& yaml_path, cv::Mat& rotation_vectors, cv::Mat& translation_vectors,
         cv::Size& image_size);

--- a/packages/camera/include/params.h
+++ b/packages/camera/include/params.h
@@ -9,17 +9,17 @@ struct CameraIntrinsicParameters {
     CameraIntrinsicParameters() = default;
 
     CameraIntrinsicParameters(
-        cv::Size size, cv::Mat camera_matrix, const cv::Vec<double, 5>& distort_coefs);
+        cv::Size size, cv::Mat camera_matrix, const cv::Vec<double, 5>& distort_coefs, const int cam_id=0);
 
-    void initUndistortMaps();
     cv::Mat undistortImage(cv::Mat& src);
 
     void storeYaml(const std::string& yaml_path) const;
-    static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path);
+    static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path, const int camera_id=0);
     static CameraIntrinsicParameters loadFromParams(
         cv::Size param_image_size, const std::vector<double>& param_camera_matrix,
         const std::vector<double>& param_dist_coefs);
 
+    int camera_id = 0;
     cv::Size image_size{};
     cv::Mat camera_matrix{};
     cv::Vec<double, 5> dist_coefs{};

--- a/packages/camera/include/params.h
+++ b/packages/camera/include/params.h
@@ -9,12 +9,13 @@ struct CameraIntrinsicParameters {
     CameraIntrinsicParameters() = default;
 
     CameraIntrinsicParameters(
-        cv::Size size, cv::Mat camera_matrix, const cv::Vec<double, 5>& distort_coefs, const int cam_id=0);
+        cv::Size size, cv::Mat camera_matrix, const cv::Vec<double, 5>& distort_coefs,
+        int cam_id = 0);
 
     cv::Mat undistortImage(cv::Mat& src);
 
     void storeYaml(const std::string& yaml_path) const;
-    static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path, const int camera_id=0);
+    static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path, int camera_id = 0);
     static CameraIntrinsicParameters loadFromParams(
         cv::Size param_image_size, const std::vector<double>& param_camera_matrix,
         const std::vector<double>& param_dist_coefs);

--- a/packages/camera/include/params.h
+++ b/packages/camera/include/params.h
@@ -17,11 +17,11 @@ struct CameraIntrinsicParameters {
     void storeYaml(const std::string& yaml_path) const;
     static CameraIntrinsicParameters loadFromYaml(const std::string& yaml_path, int camera_id = 0);
     static bool saveStereoCalibration(
-        const std::string& yaml_path, cv::Mat& rotation_vectors, cv::Mat& translation_vectors,
-        cv::Size& image_size);
+        const std::string& yaml_path, cv::Mat& rotation_vector, cv::Mat& translation_vector,
+        int camera_id);
     static void loadStereoCalibration(
-        const std::string& yaml_path, cv::Mat& rotation_vectors, cv::Mat& translation_vectors,
-        cv::Size& image_size);
+        const std::string& yaml_path, cv::Mat& rotation_vector, cv::Mat& translation_vector,
+        int camera_id);
 
     int camera_id = 0;
     cv::Size image_size{};

--- a/packages/camera/include/params.h
+++ b/packages/camera/include/params.h
@@ -19,6 +19,12 @@ struct CameraIntrinsicParameters {
     static CameraIntrinsicParameters loadFromParams(
         cv::Size param_image_size, const std::vector<double>& param_camera_matrix,
         const std::vector<double>& param_dist_coefs);
+    static bool saveStereoCalibration(
+        const std::string& yaml_path, cv::Mat& rotation_vectors, cv::Mat& translation_vectors,
+        cv::Size& image_size);
+    static void loadStereoCalibration(
+        const std::string& yaml_path, cv::Mat& rotation_vectors, cv::Mat& translation_vectors,
+        cv::Size& image_size);
 
     int camera_id = 0;
     cv::Size image_size{};

--- a/packages/camera/launch/camera.yaml
+++ b/packages/camera/launch/camera.yaml
@@ -53,15 +53,6 @@ launch:
             - { name: "saturation", value: 100 }           # range: 0-200
             - { name: "sharpness", value: 0 }              # range: 0-100
             - { name: "auto_exposure", value: False }
-        - name: "intrinsic_params"
-          param:
-            - name: "image_size"
-              param:
-                - { name: "width", value: 1920 }
-                - { name: "height", value: 1200 }
-            - { name: "camera_matrix", value: [2909.92107945441, 0., 582.1724561319506, 0.,
-                                              3134.621273608562, 532.0677320807733, 0., 0., 1.] }
-            - { name: "distorsion_coefs", value: [-0.7151398, 10.59934, 1.975451e-05, 0.07159046, 1.047479] }
     - name: "2"
       param:
         - name: "exposure_params"
@@ -74,9 +65,3 @@ launch:
             - { name: "saturation", value: 100 }           # range: 0-200
             - { name: "sharpness", value: 0 }              # range: 0-100
             - { name: "auto_exposure", value: False }
-        - name: "intrinsic_params"
-          param:
-            - { name: "image_size", value: [1920, 1200] }
-            - { name: "camera_matrix", value: [2909.92107945441, 0., 582.1724561319506, 0.,
-                                              3134.621273608562, 532.0677320807733, 0., 0., 1.] }
-            - { name: "distorsion_coefs", value: [-0.7151398, 10.59934, 1.975451e-05, 0.07159046, 1.047479] }

--- a/packages/camera/package.xml
+++ b/packages/camera/package.xml
@@ -25,6 +25,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/packages/camera/src/camera.cpp
+++ b/packages/camera/src/camera.cpp
@@ -531,4 +531,13 @@ void CameraNode::handleQueue(int camera_idx) {
     }
 }
 
+void CameraNode::initCalibParams() {
+    for (int idx = 0; idx < param_.camera_num; ++idx) {
+        RCLCPP_INFO_STREAM(this->get_logger(), "loading camera " << idx << " parameters");
+        std::string calibration_name = "camera_" + std::to_string(idx);
+        cameras_intrinsics_.push_back(
+            CameraIntrinsicParameters::loadFromYaml(param_.calibration_file_path, idx));
+    }
+}
+
 }  // namespace handy::camera

--- a/packages/camera/src/camera.cpp
+++ b/packages/camera/src/camera.cpp
@@ -140,6 +140,7 @@ CameraNode::CameraNode() : Node("camera_node") {
         }
 
         applyParamsToCamera(state_.camera_handles[i]);
+        initCalibParams(state_.camera_handles[i]);
         abortIfNot("start", CameraPlay(state_.camera_handles[i]));
         RCLCPP_INFO(
             this->get_logger(), "inited API and started camera ID = %d", camera_internal_id);
@@ -394,21 +395,6 @@ void CameraNode::applyParamsToCamera(int handle) {
         RCLCPP_ERROR(this->get_logger(), "camera %d failed to read instrinsic params", camera_idx);
         exit(EXIT_FAILURE);
     }
-
-    // loading intrinsic parameters
-    const int64_t param_image_width = this->declare_parameter<int64_t>(prefix + "image_size.width");
-    const int64_t param_image_height =
-        this->declare_parameter<int64_t>(prefix + "image_size.height");
-    const cv::Size param_image_size(param_image_width, param_image_height);
-
-    const std::vector<double> param_camera_matrix =
-        this->declare_parameter<std::vector<double>>(prefix + "camera_matrix");
-    const std::vector<double> param_dist_coefs =
-        this->declare_parameter<std::vector<double>>(prefix + "distorsion_coefs");
-
-    state_.cameras_intrinsics.push_back(CameraIntrinsicParameters::loadFromParams(
-        param_image_size, param_camera_matrix, param_dist_coefs));
-    RCLCPP_INFO(this->get_logger(), "camera=%i loaded intrinsics", camera_idx);
 }
 
 namespace {
@@ -531,13 +517,11 @@ void CameraNode::handleQueue(int camera_idx) {
     }
 }
 
-void CameraNode::initCalibParams() {
-    for (int idx = 0; idx < param_.camera_num; ++idx) {
-        RCLCPP_INFO_STREAM(this->get_logger(), "loading camera " << idx << " parameters");
-        std::string calibration_name = "camera_" + std::to_string(idx);
-        cameras_intrinsics_.push_back(
-            CameraIntrinsicParameters::loadFromYaml(param_.calibration_file_path, idx));
-    }
+void CameraNode::initCalibParams(int camera_handle) {
+    const int camera_id = getCameraId(camera_handle);
+    RCLCPP_INFO(this->get_logger(), "loading camera ID=%d parameters", camera_id);
+    state_.cameras_intrinsics.push_back(
+        CameraIntrinsicParameters::loadFromYaml(param_.calibration_file_path, camera_id));
 }
 
 }  // namespace handy::camera

--- a/packages/camera/src/params.cpp
+++ b/packages/camera/src/params.cpp
@@ -29,10 +29,12 @@ void CameraIntrinsicParameters::storeYaml(const std::string& yaml_path) const {
     YAML::Node&& camera_id_node = intrinsics[camera_id_str];
 
     camera_id_node["image_size"] = YAML::Node(YAML::NodeType::Sequence);
+    camera_id_node["image_size"].SetStyle(YAML::EmitterStyle::Flow);
     camera_id_node["image_size"].push_back(image_size.width);
     camera_id_node["image_size"].push_back(image_size.height);
 
     camera_id_node["camera_matrix"] = YAML::Node(YAML::NodeType::Sequence);
+    camera_id_node["camera_matrix"].SetStyle(YAML::EmitterStyle::Flow);
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
             camera_id_node["camera_matrix"].push_back(camera_matrix.at<double>(i, j));
@@ -40,6 +42,8 @@ void CameraIntrinsicParameters::storeYaml(const std::string& yaml_path) const {
     }
 
     camera_id_node["distortion_coefs"] = YAML::Node(YAML::NodeType::Sequence);
+    camera_id_node["distortion_coefs"].SetStyle(YAML::EmitterStyle::Flow);
+
     for (int i = 0; i < 5; ++i) {
         camera_id_node["distortion_coefs"].push_back(dist_coefs[i]);
     }
@@ -66,8 +70,9 @@ CameraIntrinsicParameters CameraIntrinsicParameters::loadFromYaml(
     const auto yaml_camera_matrix =
         intrinsics[camera_id_str]["camera_matrix"].as<std::vector<double>>();
     result.camera_matrix = cv::Mat(yaml_camera_matrix, true);
+    result.camera_matrix = result.camera_matrix.reshape(0, {3, 3});
 
-    const auto coefs = intrinsics[camera_id_str]["distorsion_coefs"].as<std::vector<float>>();
+    const auto coefs = intrinsics[camera_id_str]["distortion_coefs"].as<std::vector<float>>();
     result.dist_coefs = cv::Mat(coefs, true);
 
     result.initUndistortMaps();

--- a/packages/camera/src/params.cpp
+++ b/packages/camera/src/params.cpp
@@ -116,25 +116,6 @@ CameraIntrinsicParameters CameraIntrinsicParameters::loadFromYaml(
     const auto coefs = intrinsics[camera_id_str]["distortion_coefs"].as<std::vector<float>>();
     result.dist_coefs = cv::Mat(coefs, true);
 
-    result.initUndistortMaps();
-
-    return result;
-}
-
-CameraIntrinsicParameters CameraIntrinsicParameters::loadFromParams(
-    cv::Size param_image_size, const std::vector<double>& param_camera_matrix,
-    const std::vector<double>& param_dist_coefs) {
-    CameraIntrinsicParameters result{};
-
-    result.image_size = param_image_size;
-    result.camera_matrix = cv::Mat(param_camera_matrix, true);
-    result.dist_coefs = cv::Mat(param_dist_coefs, true);
-    result.initUndistortMaps();
-
-    return result;
-}
-
-void CameraIntrinsicParameters::initUndistortMaps() {
     // note that new camera matrix equals initial camera matrix
     // because neither scaling nor cropping is used when undistoring
     cv::initUndistortRectifyMap(

--- a/packages/camera/src/params.cpp
+++ b/packages/camera/src/params.cpp
@@ -57,7 +57,7 @@ void CameraIntrinsicParameters::storeYaml(const std::string& yaml_path) const {
 }
 
 CameraIntrinsicParameters CameraIntrinsicParameters::loadFromYaml(
-    const std::string& yaml_path, const int camera_id) {
+    const std::string& yaml_path, int camera_id) {
     CameraIntrinsicParameters result{};
     result.camera_id = camera_id;
     const std::string camera_id_str = std::to_string(camera_id);

--- a/packages/camera/test/CMakeLists.txt
+++ b/packages/camera/test/CMakeLists.txt
@@ -2,11 +2,8 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(camera_test test.cpp ../src/params.cpp)
 
-ament_target_dependencies(
-    camera_test
-    OpenCV
-    yaml_cpp_vendor)
+ament_target_dependencies(camera_test OpenCV yaml_cpp_vendor)
 
-target_include_directories(camera_test PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
-  "/usr/include")
+target_include_directories(
+  camera_test PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+                     "/usr/include")

--- a/packages/camera/test/CMakeLists.txt
+++ b/packages/camera/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 
-ament_add_gtest(camera_test main.cpp ../src/params.cpp)
+ament_add_gtest(camera_test test.cpp ../src/params.cpp)
 
 ament_target_dependencies(
     camera_test

--- a/packages/camera/test/CMakeLists.txt
+++ b/packages/camera/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+find_package(ament_cmake_gtest REQUIRED)
+
+ament_add_gtest(camera_test main.cpp ../src/params.cpp)
+
+ament_target_dependencies(
+    camera_test
+    OpenCV
+    yaml_cpp_vendor)
+
+target_include_directories(camera_test PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+  "/usr/include")

--- a/packages/camera/test/main.cpp
+++ b/packages/camera/test/main.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "params.h"
-#include <opencv2/core/core.hpp>
 #include <fstream>
+#include <opencv2/core/core.hpp>
 #include <string>
 
-TEST(camera, params_single_read_write) {
+TEST(camera, ParamsSingleReadWrite) {
     const std::string path_to_yaml = "test_params.yaml";
     cv::Mat camera_matrix = (cv::Mat_<double>(3, 3) << 1., 0., 1., 0., -2., 0., 3., 0., 3.);
     cv::Vec<float, 5> distort_coefs(1, 2, 3, 4, 5);
@@ -32,7 +32,7 @@ TEST(camera, params_single_read_write) {
     }
 }
 
-TEST(camera, params_multiple_read_write) {
+TEST(camera, ParamsMultipleReadWrite) {
     // create test params
     const std::string path_to_yaml = "test_params.yaml";
     cv::Mat camera_matrix_1 = (cv::Mat_<double>(3, 3) << 0., 0., 1., 0., -2., 0., 3., 0., 3.);

--- a/packages/camera/test/main.cpp
+++ b/packages/camera/test/main.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+
+#include "params.h"
+#include <opencv2/core/core.hpp>
+
+TEST(camera, params_read_write) {
+    cv::Mat camera_matrix = (cv::Mat_<double>(3, 3) << 1., 0., 1., 0., -2., 0., 3., 0., 3.);
+    cv::Vec<float, 5> distort_coefs(1, 2, 3, 4, 5);
+    cv::Size image_size(1920, 1080);
+
+    handy::CameraIntrinsicParameters params(image_size, camera_matrix, distort_coefs);
+    
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/packages/camera/test/main.cpp
+++ b/packages/camera/test/main.cpp
@@ -2,14 +2,84 @@
 
 #include "params.h"
 #include <opencv2/core/core.hpp>
+#include <fstream>
+#include <string>
 
-TEST(camera, params_read_write) {
+TEST(camera, params_single_read_write) {
+    const std::string path_to_yaml = "test_params.yaml";
     cv::Mat camera_matrix = (cv::Mat_<double>(3, 3) << 1., 0., 1., 0., -2., 0., 3., 0., 3.);
     cv::Vec<float, 5> distort_coefs(1, 2, 3, 4, 5);
     cv::Size image_size(1920, 1080);
 
-    handy::CameraIntrinsicParameters params(image_size, camera_matrix, distort_coefs);
-    
+    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix, distort_coefs, 0);
+    params_1.storeYaml(path_to_yaml);
+
+    std::ifstream test_file(path_to_yaml);
+    EXPECT_TRUE(test_file);  // opened successfully
+    test_file.close();
+
+    handy::CameraIntrinsicParameters params_1_check =
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 0);
+    EXPECT_EQ(image_size, params_1_check.image_size);
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; j++) {
+            EXPECT_EQ(
+                camera_matrix.at<double>(i, j), params_1_check.camera_matrix.at<double>(i, j));
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(distort_coefs[i], params_1_check.dist_coefs[i]);
+    }
+}
+
+TEST(camera, params_multiple_read_write) {
+    // create test params
+    const std::string path_to_yaml = "test_params.yaml";
+    cv::Mat camera_matrix_1 = (cv::Mat_<double>(3, 3) << 0., 0., 1., 0., -2., 0., 3., 0., 3.);
+    cv::Mat camera_matrix_2 = (cv::Mat_<double>(3, 3) << 42., 0., 1., 0.4242, -2., 0., 3., 0., 3.);
+    cv::Vec<float, 5> distort_coefs(1, 2, 3, 4, 5);
+    cv::Size image_size(1920, 1080);
+
+    // store two IDs into the same file
+    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix_1, distort_coefs, 0);
+    params_1.storeYaml(path_to_yaml);
+
+    handy::CameraIntrinsicParameters params_2(image_size, camera_matrix_2, distort_coefs, 1);
+    params_2.storeYaml(path_to_yaml);
+
+    // check for file to exist
+    std::ifstream test_file(path_to_yaml);
+    EXPECT_TRUE(test_file);  // opened successfully
+    test_file.close();
+
+    // loading and checking all params for the first ID
+    handy::CameraIntrinsicParameters params_1_check =
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 0);
+    EXPECT_EQ(image_size, params_1_check.image_size);
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; j++) {
+            EXPECT_EQ(
+                camera_matrix_1.at<double>(i, j), params_1_check.camera_matrix.at<double>(i, j));
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(distort_coefs[i], params_1_check.dist_coefs[i]);
+    }
+
+    // loading and checking all params for the second ID
+    handy::CameraIntrinsicParameters params_2_check =
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 1);
+    EXPECT_EQ(image_size, params_2_check.image_size);
+
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; j++) {
+            EXPECT_EQ(
+                camera_matrix_2.at<double>(i, j), params_2_check.camera_matrix.at<double>(i, j));
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(distort_coefs[i], params_2_check.dist_coefs[i]);
+    }
 }
 
 int main(int argc, char** argv) {

--- a/packages/camera/test/test.cpp
+++ b/packages/camera/test/test.cpp
@@ -85,12 +85,11 @@ TEST(camera, ParamsMultipleReadWrite) {
 TEST(camera, ParamsStereoCalibWrite) {
     // create test params
     const std::string path_to_yaml = "test_params.yaml";
-    cv::Mat rotation_check = (cv::Mat_<double>(3, 3) << 1., 0., 0., 0., 1., 0., 0., 0., 1.);
+    cv::Mat rotation_check = (cv::Mat_<double>(3, 1) << 111., 333., 555.);
     cv::Mat translation_check = (cv::Mat_<double>(3, 1) << 1., 2., 3.);
-    cv::Size image_size_check(1920, 1080);
 
     handy::CameraIntrinsicParameters::saveStereoCalibration(
-        path_to_yaml, rotation_check, translation_check, image_size_check);
+        path_to_yaml, rotation_check, translation_check, 1);
 
     // check for file to exist
     std::ifstream test_file(path_to_yaml);
@@ -102,17 +101,11 @@ TEST(camera, ParamsStereoCalibWrite) {
     cv::Mat translation;
     cv::Size image_size;
 
-    handy::CameraIntrinsicParameters::loadStereoCalibration(
-        path_to_yaml, rotation, translation, image_size);
+    handy::CameraIntrinsicParameters::loadStereoCalibration(path_to_yaml, rotation, translation, 1);
 
-    EXPECT_EQ(image_size, image_size_check);
     for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; j++) {
-            EXPECT_EQ(rotation_check.at<double>(i, j), rotation.at<double>(i, j));
-        }
-    }
-    for (int i = 0; i < 3; ++i) {
-        EXPECT_EQ(translation_check.at<double>(i, 0), translation.at<double>(i, 0));
+        EXPECT_EQ(rotation_check.at<double>(i), rotation.at<double>(i));
+        EXPECT_EQ(translation_check.at<double>(i), translation.at<double>(i));
     }
 }
 

--- a/packages/camera/test/test.cpp
+++ b/packages/camera/test/test.cpp
@@ -11,7 +11,7 @@ TEST(camera, ParamsSingleReadWrite) {
     cv::Vec<float, 5> distort_coefs(1, 2, 3, 4, 5);
     cv::Size image_size(1920, 1080);
 
-    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix, distort_coefs, 0);
+    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix, distort_coefs, 1);
     params_1.storeYaml(path_to_yaml);
 
     std::ifstream test_file(path_to_yaml);
@@ -19,7 +19,7 @@ TEST(camera, ParamsSingleReadWrite) {
     test_file.close();
 
     handy::CameraIntrinsicParameters params_1_check =
-        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 0);
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 1);
     EXPECT_EQ(image_size, params_1_check.image_size);
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; j++) {
@@ -27,7 +27,7 @@ TEST(camera, ParamsSingleReadWrite) {
                 camera_matrix.at<double>(i, j), params_1_check.camera_matrix.at<double>(i, j));
         }
     }
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(distort_coefs[i], params_1_check.dist_coefs[i]);
     }
 }
@@ -41,10 +41,10 @@ TEST(camera, ParamsMultipleReadWrite) {
     cv::Size image_size(1920, 1080);
 
     // store two IDs into the same file
-    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix_1, distort_coefs, 0);
+    handy::CameraIntrinsicParameters params_1(image_size, camera_matrix_1, distort_coefs, 1);
     params_1.storeYaml(path_to_yaml);
 
-    handy::CameraIntrinsicParameters params_2(image_size, camera_matrix_2, distort_coefs, 1);
+    handy::CameraIntrinsicParameters params_2(image_size, camera_matrix_2, distort_coefs, 2);
     params_2.storeYaml(path_to_yaml);
 
     // check for file to exist
@@ -54,7 +54,7 @@ TEST(camera, ParamsMultipleReadWrite) {
 
     // loading and checking all params for the first ID
     handy::CameraIntrinsicParameters params_1_check =
-        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 0);
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 1);
     EXPECT_EQ(image_size, params_1_check.image_size);
     for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; j++) {
@@ -62,13 +62,13 @@ TEST(camera, ParamsMultipleReadWrite) {
                 camera_matrix_1.at<double>(i, j), params_1_check.camera_matrix.at<double>(i, j));
         }
     }
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(distort_coefs[i], params_1_check.dist_coefs[i]);
     }
 
     // loading and checking all params for the second ID
     handy::CameraIntrinsicParameters params_2_check =
-        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 1);
+        handy::CameraIntrinsicParameters::loadFromYaml(path_to_yaml, 2);
     EXPECT_EQ(image_size, params_2_check.image_size);
 
     for (int i = 0; i < 3; ++i) {
@@ -77,8 +77,42 @@ TEST(camera, ParamsMultipleReadWrite) {
                 camera_matrix_2.at<double>(i, j), params_2_check.camera_matrix.at<double>(i, j));
         }
     }
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(distort_coefs[i], params_2_check.dist_coefs[i]);
+    }
+}
+
+TEST(camera, ParamsStereoCalibWrite) {
+    // create test params
+    const std::string path_to_yaml = "test_params.yaml";
+    cv::Mat rotation_check = (cv::Mat_<double>(3, 3) << 1., 0., 0., 0., 1., 0., 0., 0., 1.);
+    cv::Mat translation_check = (cv::Mat_<double>(3, 1) << 1., 2., 3.);
+    cv::Size image_size_check(1920, 1080);
+
+    handy::CameraIntrinsicParameters::saveStereoCalibration(
+        path_to_yaml, rotation_check, translation_check, image_size_check);
+
+    // check for file to exist
+    std::ifstream test_file(path_to_yaml);
+    EXPECT_TRUE(test_file);  // opened successfully
+    test_file.close();
+
+    // loading and checking all params for the first ID
+    cv::Mat rotation;
+    cv::Mat translation;
+    cv::Size image_size;
+
+    handy::CameraIntrinsicParameters::loadStereoCalibration(
+        path_to_yaml, rotation, translation, image_size);
+
+    EXPECT_EQ(image_size, image_size_check);
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; j++) {
+            EXPECT_EQ(rotation_check.at<double>(i, j), rotation.at<double>(i, j));
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(translation_check.at<double>(i, 0), translation.at<double>(i, 0));
     }
 }
 


### PR DESCRIPTION
<!-- Please choose all correct labels for your PR -->

<!--- Please replace <BRANCH> with the actual branch name -->
[![Test](https://github.com/robotics-laboratory/handy/actions/workflows/test.yml/badge.svg?branch=params-refactor)](https://github.com/robotics-laboratory/handy/actions/workflows/test.yml)


<!--- Optional summary of your changes -->
<!-- ## Summary -->

<!--- Please provide main changes introduced in this PR -->
## Main changes
- `CameraIntrinsicParameters` structure reworked for cleaner code and better functionality
- Intrinsic params file idea changed (see below)
- Changed to support multiple sets of params for cameras by their ID
- Added tests for camera package: minimal read/write YAML coverage
- Shortened launch of camera node: intrinsics are read by `CameraIntrinsicParameters` only from special file (see below)

OLD VERSION:
```
image_size: [1920, 1080]
camera_matrix: [0, 0, 1, 0, -2, 0, 3, 0, 3]
distortion_coefs: [1, 2, 3, 4, 5]
```
NEW VERSION (rotation and translation are from "world" to "camera")
```
parameters:
  1:
    image_size: [1920, 1080]
    camera_matrix: [0, 0, 1, 0, -2, 0, 3, 0, 3]
    distortion_coefs: [1, 2, 3, 4, 5]
    rotation: [1, 2, 3]
    translation: [1, 2, 3]
  2:
    image_size: [1920, 1080]
    camera_matrix: [42, 0, 1, 0.4242, -2, 0, 3, 0, 3]
    distortion_coefs: [1, 2, 3, 4, 5]
    rotation: [1, 2, 3]
    translation: [1, 2, 3]
```

